### PR TITLE
Add backoff time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.3] - 2023-11-19
+
+### Changed
+
+- Allow to specify a backoff time for retries with `retry_backoff`.
+- Improved the documentation in the README file.
+
 ## [1.1.2] - 2023-11-18
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -2,7 +2,15 @@
 
 An async Python wrapper for the WooCommerce REST API based on [httpx](https://www.python-httpx.org/). 
 
-This library is a fork of the original work by Claudio Sanches on [wc-api-python](https://github.com/woocommerce/wc-api-python).
+This is an _unofficial_ fork of the [WooCommerce-provided Python client](https://github.com/woocommerce/wc-api-python), originally created by Claudio Sanches.
+
+The main difference between `woocommerceaio` and the official client resides in the use of the async HTTP library [httpx](https://www.python-httpx.org/) instead of [requests](https://requests.readthedocs.io/en/latest/).
+
+Other differences include:
+
+- Support for retries.
+- Type hints.
+- And more to come (as I use the library I need to add more features)
 
 ## Installation
 
@@ -17,7 +25,7 @@ Generate API credentials (Consumer Key & Consumer Secret) following this instruc
 Check out the WooCommerce API endpoints and data that can be manipulated in http://woocommerce.github.io/woocommerce-rest-api-docs/.
 
 ## Setup
-    
+
 ```python
     from woocommerceaio import API
 
@@ -31,53 +39,51 @@ Check out the WooCommerce API endpoints and data that can be manipulated in http
 
 ## Options
 
-| Option                | Type        | Required | Description                                                                                           |
-|-----------------------|-------------|----------|-------------------------------------------------------------------------------------------------------|
-| `url`               | `string`  | yes      | Your Store URL, example: http://woo.dev/                                                              |
-| `consumer_key`      | `string`  | yes      | Your API consumer key                                                                                 |
-| `consumer_secret`   | `string`  | yes      | Your API consumer secret                                                                              |
-| `version`           | `string`  | no       | API version, default is ``wc/v3``                                                                     |
-| `timeout`           | `integer` | no       | Connection timeout, default is ``5``                                                                  |
-| `verify_ssl`        | `bool`    | no       | Verify SSL when connect, use this option as `False` when need to test with self-signed certificates |
-| `query_string_auth` | `bool`    | no       | Force Basic Authentication as query string when ``True`` and using under HTTPS, default is `False`  |
-| `user_agent`        | `string`  | no       | Set a custom User-Agent, default is `woocommerceaio/<version>`                             |
-| `oauth_timestamp`   | `integer` | no       | Custom timestamp for requests made with oAuth1.0a                                                     |
-| `wp_api`            | `bool`    | no       | Set to `False` in order to use the legacy WooCommerce API (deprecated)    
+| Option | Type | Required | Description |
+|--------|------|----------|-------------|
+| `url` | `string` | yes | Your Store URL, example: http://woo.dev/ |
+| `consumer_key` | `string`  | yes | Your API secret key |
+| `consumer_secret` | `string` | yes | Your API consumer secret |
+| `version` | `string` | no | API version, default is `wc/v3` |
+| `timeout` | `integer` | no | Connection timeout, default is `5` |
+| `verify_ssl` | `bool` | no | Verify SSL when connect, use this option as `False` when need to test with self-signed certificates |
+| `query_string_auth` | `bool` | no | Force Basic Authentication as query string when `True` and using under HTTPS, default is `False` |
+| `user_agent` | `string` | no | Set a custom User-Agent, default is `woocommerceaio/<version>` |
+| `oauth_timestamp` | `integer` | no | Custom timestamp for requests made with oAuth1.0a |
+| `wp_api` | `bool` | no | Set to `False` in order to use the legacy WooCommerce API (deprecated) |
 
 ## Methods
 
-|    Params    |      Type      |                           Description                            |
----------------|----------------|------------------------------------------------------------------|
-| `endpoint` | `string``     | WooCommerce API endpoint, example: `customers` or `order/12` |
-| `data`     | `dictionary` | Data that will be converted to JSON                              |
-| `**kwargs` | `dictionary` | Accepts `params`, also other `httpx` arguments                   |
+You can interact with the WooCommerce API using via the exposed methods `get()`, `post()`, `put()`, `delete()`, `options()`.
 
-### GET
+- All methods
 
-- `.get(endpoint, **kwargs)`
+ the following parameters.
 
-### POST
+| Params | Type | Description |
+|--------|------|-------------|
+| `endpoint` | `string` | WooCommerce API endpoint, example: `customers` or `order/12` |
+| `data` | `dictionary` | Data that will be converted to JSON |
+| `**kwargs` | `dictionary` | Accepts `params`, also other `httpx` arguments (see next section) |
 
-- `.post(endpoint, data, **kwargs)`
+### kwargs params
 
-### PUT
+`woocommerceaio` allows you to pass any `httpx` arguments as `kwargs` params. This is useful if you want to customize headers, timeouts, and other request parameters. For a list of available params, refer to the [httpx documentation](https://www.python-httpx.org/api/#request).
 
-- `.put(endpoint, data), **kwargs`
+Additionally, `woocommerceaio` provides the following custom `kwargs` params:
 
-### DELETE
+| Params | Type | Description |
+|--------|------|-------------|
+| `max_retries` | `bool` | Maximum number of retries on failed requests. Default is `3` |
+| `retry_backoff` | `float` | Backoff time to apply between attempts after the second try (most errors are resolved immediately by a second try without a delay). Default is `0.5` seconds. This value will be multiplied by a factor of two for each consequent retry. So the default delay sequence will be `0.5`, `1`, `2`, `4`, `8` etc. seconds |
 
-- `.delete(endpoint, **kwargs)`
+### Response
 
-### OPTIONS
+All methods will return an httpx [`Response`](https://www.python-httpx.org/api/#response) object. For more information on how to use this object, refer to the [httpx documentation](https://www.python-httpx.org/api/#response).
 
-- `.options(endpoint, **kwargs)`
+## Examples
 
-## Response
-
-
-All methods will return an httpx [`Response`](https://www.python-httpx.org/api/#response) object.
-
-Example of returned data:
+### Retrieving store products
 
 ```python
     >>> r = await wcapi.get("products")
@@ -93,7 +99,7 @@ Example of returned data:
     {u'products': [{u'sold_individually': False,... // Dictionary data
 ```
 
-### Request with `params` example
+### Making requests with `params`
 
 ```python
     from woocommerceaio import API

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "woocommerceaio"
 description = "An async Python wrapper for the WooCommerce REST API"
 readme = "README.md"
-version = "1.1.2"
+version = "1.1.3"
 authors = [
     { name = "Luis Medel", email = "luis@luismedel.com" },
     { name = "Claudio Sanches @ Automattic", email = "claudio+pypi@automattic.com" }

--- a/src/woocommerceaio/api.py
+++ b/src/woocommerceaio/api.py
@@ -1,4 +1,4 @@
-__version__ = "1.1.2"
+__version__ = "1.1.3"
 
 import asyncio
 import logging

--- a/src/woocommerceaio/api.py
+++ b/src/woocommerceaio/api.py
@@ -1,4 +1,4 @@
-__version__ = "1.0.1"
+__version__ = "1.1.2"
 
 import asyncio
 import logging
@@ -109,7 +109,9 @@ class API(object):
             headers=headers,
             auth=auth,
         ) as client:
-            backoff: float = 0.5
+            backoff: float = (
+                float(kwargs.pop("retry_backoff")) if "retry_backoff" in kwargs else 0.5
+            )
             _try: int = 1
 
             while True:


### PR DESCRIPTION
Main changes:
- Adds the parameter `backoff_time` to control the initial backoff time when retrying requests.
- The time will be multiplied by a factor of two on each subsequent retry.

Other changes:
- Improves a bit the README file.
